### PR TITLE
Enhance Sphinx documentation configuration

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,6 +5,7 @@
 
 # -- Path setup ----------------------------------------------------------------
 from __future__ import annotations
+
 import os
 import sys
 from datetime import datetime
@@ -62,7 +63,13 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "show_prev_next": False,
     "navigation_depth": 2,
-    # "logo": {"text": "mcframework"}, # or set an SVG logo via html_logo
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/milanfusco/mcframework",
+            "icon": "fa-brands fa-github",
+        },
+    ],
 }
 # Where to keep local assets (badges, images)
 # html_static_path = ["_static"]


### PR DESCRIPTION
This pull request makes a small update to the Sphinx documentation configuration. The main change is the addition of a GitHub icon link to the navigation bar, improving the documentation's accessibility and appearance.

Documentation theme improvements:

* Added a GitHub icon link to the `html_theme_options` in `docs/source/conf.py`, allowing users to easily navigate to the project's GitHub repository from the documentation sidebar.

Other changes:

* Minor import reordering for clarity in `docs/source/conf.py`.