### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`mcframework` is a pure-Python Monte Carlo simulation library (package in `src/mcframework`,
+installed editable). Demos live in `demos/` and the test suite in `tests/`. There is no
+long-running server; the "application" is the library plus the demo scripts.
+
+### Environment notes
+- Dependencies are installed into the system Python with `pip --break-system-packages`
+  (Ubuntu's Python is PEP 668 externally-managed). There is no virtualenv.
+- Console entry points (`pytest`, `ruff`, `pylint`) install to `~/.local/bin`, which is **not**
+  on `PATH`. Invoke tools via the module form: `python3 -m pytest`, `python3 -m ruff`,
+  `python3 -m pylint`.
+- The update script pins `matplotlib<3.11`. The demo plotting scripts call
+  `boxplot(..., labels=...)`, which matplotlib 3.11 removed (renamed to `tick_labels`).
+  With `matplotlib<3.11` (still satisfies the project's `>=3.7`) the demos run. Do not bump
+  matplotlib to 3.11+ unless the demo code is updated.
+
+### Lint / test / run (standard commands documented in README.md / CONTRIBUTING.md)
+- Lint (the gating check in CI): `python3 -m ruff check src/ tests/`. Pylint
+  (`python3 -m pylint src/mcframework tests/`) is informational only — CI runs it with
+  `continue-on-error`, so its non-zero exit on test-file style warnings is expected.
+- Tests: `python3 -m pytest`. GPU backend tests (`test_torch_cuda.py`, `test_torch_mps.py`)
+  auto-skip because there is no CUDA/MPS hardware (~37 skips is normal).
+- Demos (headless): `MPLBACKEND=Agg python3 demos/demo.py` (it calls `plt.show()` and
+  `input()`; with `Agg` the show is a no-op, and piping input avoids the save prompt).
+
+### Known environment limitation (no swap)
+- This VM has 16GB RAM and **no swap**. `tests/test_torch_cpu.py::TestTorchNumPyParity::test_torch_stats_computation_works`
+  runs the default stats engine's bootstrap CI on 100k samples, which momentarily allocates a
+  `(10_000, 100_000)` index array plus its gather (~16GB peak) and gets OOM-killed here. It
+  passes on GitHub runners because they have swap. Deselect it when running the full suite:
+  `python3 -m pytest --deselect "tests/test_torch_cpu.py::TestTorchNumPyParity::test_torch_stats_computation_works"`.
+  This is an environment constraint, not a code defect — do not "fix" the library for it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the development environment for `mcframework` (Python Monte Carlo library) in Cursor Cloud and documents non-obvious caveats for future agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering: system-Python install (`--break-system-packages`), `~/.local/bin` not on `PATH` (use `python3 -m ...`), the `matplotlib<3.11` pin needed for demos, and a no-swap OOM caveat for one heavy test.

## Environment
- Installed editable with extras matching CI: `pip install --break-system-packages -e ".[dev,test,gpu]"` plus `matplotlib<3.11` (the demos use `boxplot(labels=...)`, removed in matplotlib 3.11; `<3.11` still satisfies the project's `>=3.7`).
- The update script only refreshes dependencies (no service startup).

## Verification
- ✅ `python3 -m ruff check src/ tests/` — all checks passed
- ✅ `python3 -m pytest --deselect "tests/test_torch_cpu.py::TestTorchNumPyParity::test_torch_stats_computation_works"` — 279 passed, 37 skipped (GPU tests, no CUDA/MPS), 85% coverage
- ⚠️ `test_torch_stats_computation_works` deselected — its default-engine bootstrap CI on 100k samples needs ~16GB peak and OOMs on this swap-less VM; passes on CI runners (which have swap)
- ✅ `MPLBACKEND=Agg python3 demos/demo.py` — runs end-to-end and renders the Pi Estimation / Portfolio analyses

### Demo output
[Pi Estimation Monte Carlo analysis](https://cursor.com/agents/bc-667760b9-a419-4e9e-956b-7d224550307d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpi_estimation_analysis.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-667760b9-a419-4e9e-956b-7d224550307d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-667760b9-a419-4e9e-956b-7d224550307d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

