### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 [project]
 name = "mcframework"
-version = "0.2.0"
+version = "0.3.0"
 description = "Lightweight, parallel, and reproducible Monte Carlo simulation framework"
 readme = "README.md"
 authors = [{ name = "Milan Fusco" }]


### PR DESCRIPTION
## Summary

Bump the package version to 0.3.0 in preparation for the next PyPI release.

Everything merged since the published 0.2.0 is in this release, including breaking changes (removal of backward-compat aliases, the deprecated `parallel` parameter, and the `cupy_batch` shim), new features (`curand_batch` API, benchmark `--quick` mode), CI/coverage improvements, and the documentation overhaul.

Verified locally: `python -m build` succeeds and `twine check` passes for both the wheel and sdist.

## After merge

Publishing the `v0.3.0` GitHub release will tag `main` and trigger `publish.yml` to upload to PyPI via OIDC.