### PR TITLE
fix(stats): warn instead of raise on small n_bootstrap

### DIFF
--- a/src/mcframework/stats_engine.py
+++ b/src/mcframework/stats_engine.py
@@ -359,9 +359,11 @@ class StatsContext:
             if self.ess <= 0:
                 raise ValueError(f"ess must be positive, got {self.ess}")
 
-        # Warn about small bootstrap samples (but don't fail)
+        # Warn about small bootstrap samples (a quality concern, not invalid input)
         if self.n_bootstrap < 100:
-            raise ValueError(f"n_bootstrap ({self.n_bootstrap}) should be >= 100 for reliable estimates")
+            logger.warning(
+                "n_bootstrap (%d) should be >= 100 for reliable estimates", self.n_bootstrap
+            )
 
 
 @dataclass(frozen=True)

--- a/tests/test_stats_engine_edge_cases.py
+++ b/tests/test_stats_engine_edge_cases.py
@@ -263,9 +263,11 @@ def test_stats_context_cross_field_validations():
     with pytest.raises(ValueError, match="ess must be positive"):
         StatsContext(n=10, ess=0)
 
-    # Test n_bootstrap < 100 raises error
-    with pytest.raises(ValueError, match="n_bootstrap .* should be >= 100"):
-        StatsContext(n=10, n_bootstrap=50)
+    # n_bootstrap <= 0 is invalid and raises
+    with pytest.raises(ValueError, match="n_bootstrap must be > 0"):
+        StatsContext(n=10, n_bootstrap=0)
+    # n_bootstrap < 100 is a quality concern: it warns but does not raise
+    assert StatsContext(n=10, n_bootstrap=50).n_bootstrap == 50
 
     # Valid cases should not raise
     ctx = StatsContext(n=100, ess=50, n_bootstrap=1000)


### PR DESCRIPTION
## Summary
- `StatsContext.__post_init__` raised `ValueError` for `n_bootstrap < 100`, contradicting the adjacent comment ("warn ... but don't fail") and the documented default behavior.
- A low but positive `n_bootstrap` is a result-quality concern, not invalid input, so it is downgraded to `logger.warning`.
- The hard `ValueError` for `n_bootstrap <= 0` is preserved.

## Behavior change
- `n_bootstrap` in `[1, 99]` now warns instead of raising. The matching test in `tests/test_stats_engine_edge_cases.py` was updated accordingly.

## Test plan
- [x] `python -m pytest tests/test_stats_engine_edge_cases.py`
- [x] `python -m ruff check src/mcframework/stats_engine.py tests/test_stats_engine_edge_cases.py`

From the code review of `src/`. Part 1 of 4.