### PR TITLE
docs: clarify backend/threshold reproducibility caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,18 @@ print(result.result_to_string())
 | `"process"` | `backend="process"` (Windows default) | `ProcessPoolExecutor`, avoids GIL serialization |
 | `"torch"` | `backend="torch", torch_device="cpu"|"mps"|"cuda"` | Vectorized batching on CPU, Apple Silicon, or NVIDIA GPU |
 
+### Reproducibility note
+
+Determinism is **per-(backend, block-layout)**, not absolute. The sequential
+backend draws all samples from a single spawned stream, while the thread/process
+backends spawn one stream per work block (block count depends on `n_workers`,
+`n_simulations`, and the chunk factor). Since `backend="auto"` switches from
+sequential to parallel once `n_simulations` crosses `20_000`, the same `seed`
+can yield different draws above vs. below that threshold, and sequential and
+parallel runs are not bitwise identical. Pin `backend` and `n_workers` for
+run-to-run reproducible numbers; statistical properties (mean, variance, CI
+coverage) hold regardless.
+
 ## Performance
 
 ![Backend performance comparison on Apple Silicon](https://raw.githubusercontent.com/milanfusco/mcFramework/main/demos/apple_silicon_benchmark.png)

--- a/src/mcframework/simulation.py
+++ b/src/mcframework/simulation.py
@@ -321,7 +321,27 @@ class MonteCarloSimulation(ABC):
         -----
         The framework spawns independent child sequences per worker/chunk via
         :meth:`numpy.random.SeedSequence.spawn`, ensuring deterministic parallel
-        streams given the same ``seed`` and block layout.
+        streams given the same ``seed`` *and the same block layout*.
+
+        .. warning::
+
+           Reproducibility is per-(backend, block-layout), **not** absolute. The
+           number of spawned child streams depends on the resolved backend and
+           the work partition:
+
+           - The sequential backend spawns **one** child stream and draws every
+             sample from it.
+           - The thread/process backends spawn **one child stream per block**,
+             where the block count depends on ``n_workers``, ``n_simulations``,
+             and ``_CHUNKS_PER_WORKER``.
+
+           Because ``backend="auto"`` switches from sequential to parallel once
+           ``n_simulations`` crosses :attr:`_PARALLEL_THRESHOLD`
+           (``20_000``), the *same* ``seed`` can produce different draws above vs.
+           below that threshold, and sequential vs. parallel results are not
+           bitwise identical. For run-to-run reproducible numbers, pin the
+           backend and ``n_workers`` explicitly. Statistical properties (mean,
+           variance, CI coverage) are unaffected.
         """
         self.seed_seq = np.random.SeedSequence(seed)
         self.rng = np.random.default_rng(self.seed_seq)


### PR DESCRIPTION
## Summary
Documents a reproducibility caveat surfaced in the `src/` review (docs-only, no seed-layout change):

- Determinism is **per-(backend, block-layout)**, not absolute. The sequential backend draws all samples from a single spawned stream; the thread/process backends spawn one stream per work block (count depends on `n_workers`, `n_simulations`, and the chunk factor).
- Because `backend="auto"` switches from sequential to parallel at `_PARALLEL_THRESHOLD` (`20_000`), the same `seed` can produce different draws above vs. below that threshold, and sequential vs. parallel runs are not bitwise identical.
- Guidance: pin `backend` and `n_workers` for run-to-run reproducible numbers; statistical properties (mean, variance, CI coverage) hold regardless.
- Updated the `set_seed()` docstring and the README "Execution Backends" section.

## Test plan
- [x] `python -m ruff check src/mcframework/simulation.py`
- [x] Import smoke check

From the code review of `src/`. Part 4 of 4.