### PR TITLE
feat(validation): oracle convergence harness + analytic_reference hook

### DIFF
--- a/docs/source/api/_modules/validation.rst
+++ b/docs/source/api/_modules/validation.rst
@@ -1,0 +1,107 @@
+Validation Module
+=================
+
+.. currentmodule:: mcframework.validation
+
+The validation module turns "does my simulation converge to the right answer?" into a
+single, repeatable call. Given a simulation that declares an analytic reference
+("oracle") via :meth:`~mcframework.core.MonteCarloSimulation.analytic_reference`, it
+runs the simulation and reports whether the Monte Carlo estimate lands on the known
+value.
+
+Overview
+--------
+
+A Monte Carlo estimator :math:`\widehat{\theta}_n` is trustworthy only insofar as you
+can check it. When a closed-form answer :math:`\theta` exists, that answer is an
+*oracle*: a checkable ground truth. This module threads the oracle through the stats
+engine's existing ``target`` machinery and reports two complementary checks:
+
+- ``within_ci``  -- the oracle lies inside the computed confidence interval.
+- ``within_tol`` -- the absolute error is within ``sigma_tol`` standard errors:
+
+.. math::
+
+   \left| \widehat{\theta}_n - \theta \right| \le k \cdot \mathrm{SE},
+   \qquad \mathrm{SE} = \frac{s}{\sqrt{n}},
+
+with :math:`k = \texttt{sigma\_tol}` (default 5). At a fixed seed this check is
+essentially never flaky, yet a genuine implementation bug lands many standard errors
+away and fails loudly. That makes it an ideal CI gate.
+
+Usage
+-----
+
+.. code-block:: python
+
+   from mcframework import validate_convergence, PiEstimationSimulation
+
+   report = validate_convergence(PiEstimationSimulation(), 200_000, seed=0)
+   print(report.status)      # "pass"
+   print(report.estimate)    # ≈ 3.14159
+   print(report.abs_error)   # small multiple of the standard error
+
+If a simulation has no oracle, the report's ``status`` is ``"no-oracle"`` and no run is
+performed — a deliberate signal that the simulation is research, not a verifiable demo:
+
+.. code-block:: python
+
+   report = validate_convergence(SomeResearchSim(), 10_000)
+   assert report.status == "no-oracle"
+
+Adding an oracle to a custom simulation
+---------------------------------------
+
+Override :meth:`~mcframework.core.MonteCarloSimulation.analytic_reference` to return the
+known expected value of a single draw, and set ``reference_source`` to cite it:
+
+.. code-block:: python
+
+   import math
+   from mcframework import MonteCarloSimulation
+
+   class PiSim(MonteCarloSimulation):
+       reference_source = "Closed form: 4 * P(X^2 + Y^2 <= 1) = pi"
+
+       def single_simulation(self, _rng=None, **kwargs):
+           ...
+
+       def analytic_reference(self, **params):
+           return math.pi
+
+
+Module Reference
+----------------
+
+.. automodule:: mcframework.validation
+   :no-members:
+   :no-undoc-members:
+   :no-inherited-members:
+
+Classes
+~~~~~~~
+
+.. autosummary::
+   :toctree: generated
+   :recursive:
+   :nosignatures:
+
+   ConvergenceReport
+
+Functions
+~~~~~~~~~
+
+.. autosummary::
+   :toctree: generated
+   :recursive:
+   :nosignatures:
+
+   validate_convergence
+
+
+See Also
+--------
+
+- :doc:`stats_engine`: Provides the ``target``-based metrics and ``ci_mean`` reused here
+- :meth:`~mcframework.core.MonteCarloSimulation.analytic_reference`: The oracle hook
+- :func:`~mcframework.stats_engine.ci_mean`: Parametric CI for the mean

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -218,6 +218,7 @@ The ``backend`` parameter controls execution strategy:
    api/_modules/stats_engine
    api/_modules/sims
    api/_modules/utils
+   api/_modules/validation
 
 
 Indices and tables

--- a/src/mcframework/__init__.py
+++ b/src/mcframework/__init__.py
@@ -13,6 +13,7 @@ from .sims import (
 )
 from .stats_engine import DEFAULT_ENGINE, FnMetric, StatsContext, StatsEngine
 from .utils import autocrit, t_crit, z_crit
+from .validation import ConvergenceReport, validate_convergence
 
 __all__ = [
     "SimulationResult",
@@ -26,6 +27,8 @@ __all__ = [
     "StatsContext",
     "FnMetric",
     "DEFAULT_ENGINE",
+    "ConvergenceReport",
+    "validate_convergence",
     "z_crit",
     "t_crit",
     "autocrit",

--- a/src/mcframework/simulation.py
+++ b/src/mcframework/simulation.py
@@ -111,6 +111,10 @@ class MonteCarloSimulation(ABC):
     #: Override in subclass by setting ``supports_batch = True``.
     _supports_batch: bool = False
 
+    #: Citation for the simulation's analytic reference / oracle, e.g.
+    #: ``"Black-Scholes-Merton (1973)"``. Empty when no oracle is declared.
+    reference_source: str = ""
+
     @property
     def supports_batch(self) -> bool:
         """
@@ -305,6 +309,40 @@ class MonteCarloSimulation(ABC):
             A 1D array of length ``n`` containing simulation results.
         """
         raise NotImplementedError
+
+    def analytic_reference(self, **params: Any) -> float | None:
+        r"""
+        Known expected value of :meth:`single_simulation` ("oracle"), if one exists.
+
+        Override in subclasses that have a closed-form or otherwise-known answer for
+        :math:`\mathbb{E}[\texttt{single\_simulation}]` under the given parameters.
+        The value is consumed by :func:`mcframework.validation.validate_convergence`
+        to assert that the Monte Carlo estimate converges to ground truth.
+
+        Parameters
+        ----------
+        **params : Any
+            The same keyword parameters passed to :meth:`single_simulation` / :meth:`run`,
+            so the reference can depend on the configuration.
+
+        Returns
+        -------
+        float or None
+            The oracle value, or ``None`` (default) when no reference exists. Returning
+            ``None`` signals that the simulation has no oracle and cannot be convergence
+            -validated (it is research, not a verifiable demo).
+
+        Examples
+        --------
+        >>> import math
+        >>> class PiSim(MonteCarloSimulation):
+        ...     reference_source = "Closed form: pi"
+        ...     def single_simulation(self, _rng=None):
+        ...         ...
+        ...     def analytic_reference(self, **params):
+        ...         return math.pi
+        """
+        return None
 
     def set_seed(self, seed: int | None) -> None:
         r"""

--- a/src/mcframework/validation.py
+++ b/src/mcframework/validation.py
@@ -1,0 +1,205 @@
+r"""
+Convergence validation against analytic references ("oracles").
+
+A Monte Carlo simulation is only as trustworthy as your ability to check it. This
+module turns that check into a first-class, repeatable operation: given a simulation
+that declares a known answer via
+:meth:`~mcframework.core.MonteCarloSimulation.analytic_reference`, it runs the
+simulation and asserts that the estimate converges to that answer.
+
+The implementation is deliberately thin: it reuses the stats engine's existing
+``target`` machinery (:func:`~mcframework.stats_engine.bias_to_target`,
+:func:`~mcframework.stats_engine.mse_to_target`) and the confidence interval from
+:func:`~mcframework.stats_engine.ci_mean`. The oracle is simply passed through as the
+context ``target``.
+
+Two complementary checks are reported:
+
+- ``within_ci``  -- the oracle lies inside the computed confidence interval.
+- ``within_tol`` -- the absolute error is within ``sigma_tol`` standard errors.
+
+``within_tol`` at a fixed seed is the recommended CI gate: it is statistically
+principled, essentially never flaky, yet a genuine implementation bug lands many
+standard errors away and fails loudly.
+
+Example
+-------
+>>> import math
+>>> from mcframework.validation import validate_convergence
+>>> # report = validate_convergence(PiSim(), 200_000)  # doctest: +SKIP
+>>> # report.status, round(report.estimate, 2)  # doctest: +SKIP
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from .simulation import MonteCarloSimulation
+
+__all__ = ["ConvergenceReport", "validate_convergence"]
+
+
+@dataclass(frozen=True)
+class ConvergenceReport:
+    r"""
+    Outcome of a convergence check against a simulation's analytic reference.
+
+    Attributes
+    ----------
+    status : {"pass", "fail", "no-oracle"}
+        ``"no-oracle"`` if the simulation does not declare an
+        :meth:`~mcframework.core.MonteCarloSimulation.analytic_reference`;
+        otherwise ``"pass"``/``"fail"`` from ``within_tol``.
+    n : int
+        Number of simulation draws used.
+    oracle : float or None
+        The known reference value (``None`` when no oracle exists).
+    estimate : float or None
+        The Monte Carlo estimate of the mean.
+    abs_error : float or None
+        ``|estimate - oracle|``.
+    rel_error : float or None
+        ``abs_error / |oracle|`` (``None`` when ``oracle`` is ``0`` or missing).
+    se : float or None
+        Standard error of the mean.
+    ci_low, ci_high : float or None
+        Confidence-interval endpoints for the mean.
+    within_ci : bool
+        Whether ``oracle`` lies within ``[ci_low, ci_high]``.
+    within_tol : bool
+        Whether ``abs_error <= sigma_tol * se``.
+    sigma_tol : float
+        Standard-error multiplier used for ``within_tol``.
+    confidence : float
+        Confidence level used for the interval.
+    reference_source : str
+        Citation for the oracle, copied from the simulation.
+    """
+
+    status: str
+    n: int
+    oracle: float | None = None
+    estimate: float | None = None
+    abs_error: float | None = None
+    rel_error: float | None = None
+    se: float | None = None
+    ci_low: float | None = None
+    ci_high: float | None = None
+    within_ci: bool = False
+    within_tol: bool = False
+    sigma_tol: float = 5.0
+    confidence: float = 0.99
+    reference_source: str = ""
+
+
+def _ci_bounds(ci: Any) -> tuple[float, float] | None:
+    """Extract (low, high) from the engine's ci_mean dict or the legacy tuple form."""
+    if isinstance(ci, dict) and "low" in ci and "high" in ci:
+        return float(ci["low"]), float(ci["high"])
+    if isinstance(ci, (tuple, list)) and len(ci) == 2:
+        return float(ci[0]), float(ci[1])
+    return None
+
+
+def validate_convergence(
+    sim: MonteCarloSimulation,
+    n: int,
+    *,
+    sigma_tol: float = 5.0,
+    confidence: float = 0.99,
+    seed: int = 0,
+    **params: Any,
+) -> ConvergenceReport:
+    r"""
+    Check that a simulation's Monte Carlo estimate converges to its analytic reference.
+
+    Parameters
+    ----------
+    sim : MonteCarloSimulation
+        The simulation to validate. Must implement
+        :meth:`~mcframework.core.MonteCarloSimulation.analytic_reference` to be
+        checkable; otherwise a ``"no-oracle"`` report is returned.
+    n : int
+        Number of simulation draws.
+    sigma_tol : float, default 5.0
+        Tolerance for ``ConvergenceReport.within_tol``, expressed as a multiple of
+        the standard error. The default of ``5`` sigma makes a fixed-seed check
+        essentially non-flaky while still catching real bugs.
+    confidence : float, default 0.99
+        Confidence level for the interval used by ``ConvergenceReport.within_ci``.
+    seed : int, default 0
+        Seed applied via :meth:`~mcframework.core.MonteCarloSimulation.set_seed`
+        for reproducible validation.
+    **params : Any
+        Forwarded to both :meth:`~mcframework.core.MonteCarloSimulation.analytic_reference`
+        and :meth:`~mcframework.core.MonteCarloSimulation.run`, so the oracle and the
+        run use identical parameters.
+
+    Returns
+    -------
+    ConvergenceReport
+        The structured outcome. ``status`` is ``"no-oracle"`` when no reference is
+        declared, else ``"pass"``/``"fail"`` based on ``ConvergenceReport.within_tol``.
+
+    Notes
+    -----
+    The oracle is threaded through the stats engine as the context ``target`` (via
+    ``run(..., extra_context={"target": oracle})``), which also populates
+    ``bias_to_target``/``mse_to_target`` in the result for free.
+    """
+    oracle = sim.analytic_reference(**params)
+    reference_source = getattr(sim, "reference_source", "")
+
+    if oracle is None:
+        return ConvergenceReport(
+            status="no-oracle",
+            n=n,
+            sigma_tol=sigma_tol,
+            confidence=confidence,
+            reference_source=reference_source,
+        )
+
+    oracle = float(oracle)
+    sim.set_seed(seed)
+    res = sim.run(
+        n,
+        confidence=confidence,
+        extra_context={"target": oracle},
+        **params,
+    )
+
+    estimate = float(res.mean)
+    abs_error = abs(estimate - oracle)
+    rel_error = abs_error / abs(oracle) if oracle != 0.0 else None
+    se = float(res.std) / np.sqrt(max(1, n))
+
+    bounds = _ci_bounds(res.stats.get("ci_mean"))
+    if bounds is not None:
+        ci_low, ci_high = bounds
+        within_ci = ci_low <= oracle <= ci_high
+    else:
+        ci_low = ci_high = None
+        within_ci = False
+
+    within_tol = abs_error <= sigma_tol * se
+
+    return ConvergenceReport(
+        status="pass" if within_tol else "fail",
+        n=n,
+        oracle=oracle,
+        estimate=estimate,
+        abs_error=abs_error,
+        rel_error=rel_error,
+        se=se,
+        ci_low=ci_low,
+        ci_high=ci_high,
+        within_ci=within_ci,
+        within_tol=within_tol,
+        sigma_tol=sigma_tol,
+        confidence=confidence,
+        reference_source=reference_source,
+    )

--- a/src/mcframework/validation.py
+++ b/src/mcframework/validation.py
@@ -178,12 +178,12 @@ def validate_convergence(
     se = float(res.std) / np.sqrt(max(1, n))
 
     bounds = _ci_bounds(res.stats.get("ci_mean"))
+    ci_low: float | None = None
+    ci_high: float | None = None
+    within_ci = False
     if bounds is not None:
         ci_low, ci_high = bounds
         within_ci = ci_low <= oracle <= ci_high
-    else:
-        ci_low = ci_high = None
-        within_ci = False
 
     within_tol = abs_error <= sigma_tol * se
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,93 @@
+"""
+Tests for the oracle/convergence validation harness (``mcframework.validation``).
+
+These exercise the reusable engine with tiny inline simulations whose true mean is
+known in closed form, so the behavior is exact and seed-deterministic.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.random import Generator
+
+from mcframework import ConvergenceReport, validate_convergence
+from mcframework.core import MonteCarloSimulation
+
+
+class UniformMeanSim(MonteCarloSimulation):
+    """Each draw is Uniform(0, 1); E[draw] = 0.5 is the oracle."""
+
+    reference_source = "Closed form: E[Uniform(0,1)] = 1/2"
+
+    def __init__(self):
+        super().__init__("Uniform Mean")
+
+    def single_simulation(self, _rng: Generator | None = None, **kwargs) -> float:
+        rng = self._rng(_rng, self.rng)
+        return float(rng.uniform(0.0, 1.0))
+
+    def analytic_reference(self, **params) -> float:
+        return 0.5
+
+
+class NoOracleSim(MonteCarloSimulation):
+    """A simulation that declares no analytic reference."""
+
+    def __init__(self):
+        super().__init__("No Oracle")
+
+    def single_simulation(self, _rng: Generator | None = None, **kwargs) -> float:
+        rng = self._rng(_rng, self.rng)
+        return float(rng.uniform(0.0, 1.0))
+
+
+class WrongOracleSim(UniformMeanSim):
+    """Same Uniform(0,1) draws but a deliberately wrong oracle far from 0.5."""
+
+    def analytic_reference(self, **params) -> float:
+        return 5.0
+
+
+def test_pass_within_tolerance():
+    report = validate_convergence(UniformMeanSim(), 20_000, seed=0)
+    assert isinstance(report, ConvergenceReport)
+    assert report.status == "pass"
+    assert report.within_tol
+    assert report.oracle == 0.5
+    assert report.abs_error is not None and report.abs_error < 0.05
+    assert report.reference_source.startswith("Closed form")
+    # The 99% CI should bracket the true mean for a correct estimator.
+    assert report.within_ci
+
+
+def test_no_oracle_path():
+    report = validate_convergence(NoOracleSim(), 1_000)
+    assert report.status == "no-oracle"
+    assert report.oracle is None
+    assert report.estimate is None
+    assert not report.within_tol
+
+
+def test_wrong_oracle_fails():
+    report = validate_convergence(WrongOracleSim(), 20_000, seed=0)
+    assert report.status == "fail"
+    assert not report.within_tol
+    assert not report.within_ci
+    # A wrong oracle should be many standard errors away.
+    assert report.abs_error is not None and report.se is not None
+    assert report.abs_error > report.sigma_tol * report.se
+
+
+def test_reproducible_at_fixed_seed():
+    a = validate_convergence(UniformMeanSim(), 5_000, seed=123)
+    b = validate_convergence(UniformMeanSim(), 5_000, seed=123)
+    assert a.estimate == b.estimate
+    assert a.se == b.se
+
+
+def test_rel_error_and_se_are_consistent():
+    report = validate_convergence(UniformMeanSim(), 10_000, seed=7)
+    assert report.rel_error == pytest.approx(report.abs_error / abs(report.oracle))
+    # se = std / sqrt(n); std for Uniform(0,1) is 1/sqrt(12) ≈ 0.289, so se ≈ 0.00289.
+    assert report.se == pytest.approx(1.0 / np.sqrt(12) / np.sqrt(10_000), rel=0.1)


### PR DESCRIPTION
## Summary
First PR of the Oracle and Benchmark Validation System. Adds a reusable, CI-gateable convergence-validation layer so any simulation can prove it converges to a known answer. Ships the engine only; no sims are wired yet (kept small and independently mergeable).

- **Hook**: `MonteCarloSimulation.analytic_reference(**params) -> float | None` (default `None`) plus a `reference_source` citation attribute.
- **Harness** (`validation.py`): `ConvergenceReport` dataclass and `validate_convergence(sim, n, *, sigma_tol=5.0, confidence=0.99, seed=0, **params)`. Reuses the stats engine's existing `target` machinery by passing the oracle through `run(extra_context={"target": oracle})`, and reads the CI from `res.stats["ci_mean"]` (handles both the engine dict and the legacy tuple form). Reports `within_ci` and `within_tol = abs_err <= sigma_tol*SE`; `status` is `pass` / `fail` / `no-oracle`.
- **Exports**: `validate_convergence`, `ConvergenceReport` from the package root.
- **Docs**: `docs/source/api/_modules/validation.rst` added to the API toctree (builds clean, no new Sphinx warnings).

## Test plan
- [x] `python3 -m ruff check src/ tests/` clean
- [x] `tests/test_validation.py` (5 tests): pass-within-tol, no-oracle path, deliberately-wrong oracle fails, fixed-seed reproducibility, SE consistency
- [x] Full suite: 313 passed, 39 skipped (only the known sandbox `ProcessPoolExecutor` semaphore failure, environmental)
- [x] Sphinx HTML build: no new warnings from the validation module