### PR TITLE
feat(oracle-sims): closed-form oracles + regression tests

### DIFF
--- a/docs/source/guides/validation.md
+++ b/docs/source/guides/validation.md
@@ -1,0 +1,109 @@
+# Oracles and Benchmarks
+
+A Monte Carlo estimate is only trustworthy if you can check it. `mcframework` makes
+"converges to a known answer" a first-class, repeatable operation: when a simulation
+has a closed-form answer, it declares that answer as an **oracle**, and
+{func}`~mcframework.validation.validate_convergence` asserts the estimate lands on it.
+
+## The idea: oracle = checkable ground truth
+
+An *oracle* is a value you already know to be correct: the analytic expectation of a
+single draw. If the Monte Carlo mean does not converge to the oracle, the estimator is
+wrong — full stop. This turns correctness into a test instead of a vibe.
+
+`mcframework` reuses machinery it already has. The oracle is passed straight through to
+the stats engine as the context `target` (via `run(extra_context={"target": oracle})`),
+which also populates `bias_to_target` / `mse_to_target` for free. Validation is a thin
+pass/fail layer over the confidence interval the engine already computes.
+
+Two complementary checks are reported:
+
+- **`within_ci`** — the oracle lies inside the computed confidence interval.
+- **`within_tol`** — the absolute error is within `sigma_tol` standard errors:
+
+```{math}
+\left| \widehat{\theta}_n - \theta \right| \le k \cdot \mathrm{SE},
+\qquad \mathrm{SE} = \frac{s}{\sqrt{n}}, \quad k = \texttt{sigma\_tol}.
+```
+
+`within_tol` at a fixed seed is the recommended CI gate: it is statistically principled,
+essentially never flaky (a 5σ false failure is a ~1-in-1.7-million event), yet a real
+implementation bug lands many standard errors away and fails loudly.
+
+## Quick start
+
+```python
+from mcframework import validate_convergence, BlackScholesSimulation
+
+report = validate_convergence(BlackScholesSimulation(), 50_000, seed=0, option_type="call")
+print(report.status)      # "pass"
+print(report.estimate)    # Monte Carlo price
+print(report.oracle)      # closed-form Black-Scholes-Merton price
+print(report.abs_error)   # within a few standard errors
+```
+
+If a simulation declares no oracle, no run is performed and `status` is `"no-oracle"` —
+a deliberate signal that the simulation is research, not a verifiable demo:
+
+```python
+report = validate_convergence(BlackScholesSimulation(), 1_000, exercise_type="american")
+assert report.status == "no-oracle"   # American options have no closed form
+```
+
+## Built-in oracles
+
+These ship validated and are pinned by `tests/test_oracles.py`:
+
+| Simulation | Oracle | Reference |
+| --- | --- | --- |
+| {class}`~mcframework.sims.PiEstimationSimulation` | $\pi$ | Closed form: $4\,\Pr(X^2+Y^2\le 1)=\pi$ |
+| {class}`~mcframework.sims.PortfolioSimulation` (GBM) | $V_0 e^{\mu T}$ | Risk-neutral GBM expectation |
+| {class}`~mcframework.sims.BlackScholesPathSimulation` | $S_0 e^{rT}$ | Risk-neutral GBM terminal price |
+| {class}`~mcframework.sims.BlackScholesSimulation` (European) | $C, P$ | Black-Scholes-Merton (1973) |
+| {class}`~mcframework.sims.BlackScholesSimulation` (American) | *none* | No closed form → not validated |
+
+The Black-Scholes-Merton closed form for a European option is
+
+```{math}
+C = S_0\,\Phi(d_1) - K e^{-rT}\,\Phi(d_2), \qquad
+P = K e^{-rT}\,\Phi(-d_2) - S_0\,\Phi(-d_1),
+```
+
+with $d_1 = \dfrac{\ln(S_0/K) + (r + \tfrac12\sigma^2)T}{\sigma\sqrt T}$ and
+$d_2 = d_1 - \sigma\sqrt T$.
+
+## Adding an oracle to your own simulation
+
+Override {meth}`~mcframework.core.MonteCarloSimulation.analytic_reference` to return the
+known expected value of a single draw under the given parameters, and set
+`reference_source` to cite it. Return `None` when no oracle exists.
+
+```python
+import math
+from mcframework import MonteCarloSimulation, validate_convergence
+
+class CoinFlipSimulation(MonteCarloSimulation):
+    reference_source = "Closed form: E[Bernoulli(p)] = p"
+
+    def __init__(self, p: float = 0.5):
+        super().__init__("Coin Flip")
+        self.p = p
+
+    def single_simulation(self, _rng=None, **kwargs):
+        rng = self._rng(_rng, self.rng)
+        return float(rng.random() < self.p)
+
+    def analytic_reference(self, **params):
+        return self.p
+
+report = validate_convergence(CoinFlipSimulation(0.3), 100_000, seed=0)
+assert report.status == "pass"
+```
+
+`analytic_reference` receives the same keyword parameters as `run` / `single_simulation`,
+so the oracle can depend on configuration (strike, drift, etc.). Keep the reference a
+genuine closed form or a cited benchmark — never a second Monte Carlo estimate.
+
+```{seealso}
+{doc}`../api/_modules/validation` for the full API reference.
+```

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -200,6 +200,7 @@ The ``backend`` parameter controls execution strategy:
    :caption: User Guide
 
    getting-started
+   guides/validation
    guides/cuda
    guides/mps
 

--- a/src/mcframework/sims/black_scholes.py
+++ b/src/mcframework/sims/black_scholes.py
@@ -8,6 +8,7 @@ import logging
 
 import numpy as np
 from numpy.random import Generator
+from scipy.stats import norm  # type: ignore[import-untyped]
 
 from ..core import MonteCarloSimulation
 
@@ -224,9 +225,49 @@ class BlackScholesSimulation(MonteCarloSimulation):
         Simulation name. Defaults to "Black-Scholes Option Pricing".
     """
 
+    reference_source = "Black-Scholes-Merton (1973), closed-form European price"
+
     def __init__(self, name: str = "Black-Scholes Option Pricing"):
         super().__init__(name)
         self._american_bias_warned = False
+
+    def analytic_reference(
+        self,
+        *,
+        S0: float = 100.0,
+        K: float = 100.0,
+        T: float = 1.0,
+        r: float = 0.05,
+        sigma: float = 0.20,
+        option_type: str = "call",
+        exercise_type: str = "european",
+        **params,
+    ) -> float | None:
+        r"""
+        Closed-form Black-Scholes-Merton price (the oracle for European exercise).
+
+        .. math::
+           C = S_0\,\Phi(d_1) - K e^{-rT}\,\Phi(d_2), \qquad
+           P = K e^{-rT}\,\Phi(-d_2) - S_0\,\Phi(-d_1),
+
+        with :math:`d_1 = \frac{\ln(S_0/K) + (r + \tfrac12\sigma^2)T}{\sigma\sqrt T}`
+        and :math:`d_2 = d_1 - \sigma\sqrt T`.
+
+        Returns ``None`` for ``exercise_type="american"``: an American option has no
+        closed-form price, so it is deliberately not convergence-validated. That
+        absence is itself the governance signal.
+        """
+        if exercise_type != "european":
+            return None
+        if option_type not in ("call", "put"):
+            raise ValueError(f"option_type must be 'call' or 'put', got '{option_type}'")
+        sqrt_t = sigma * np.sqrt(T)
+        d1 = (np.log(S0 / K) + (r + 0.5 * sigma * sigma) * T) / sqrt_t
+        d2 = d1 - sqrt_t
+        disc_k = K * np.exp(-r * T)
+        if option_type == "call":
+            return float(S0 * norm.cdf(d1) - disc_k * norm.cdf(d2))
+        return float(disc_k * norm.cdf(-d2) - S0 * norm.cdf(-d1))
 
     def single_simulation(  # pylint: disable=arguments-differ
         self,
@@ -483,8 +524,21 @@ class BlackScholesPathSimulation(MonteCarloSimulation):
     Simulate stock price paths under Black-Scholes dynamics.
     """
 
+    reference_source = "Risk-neutral GBM: E[S_T] = S0 * exp(r * T)"
+
     def __init__(self, name: str = "Black-Scholes Path Simulation"):
         super().__init__(name)
+
+    def analytic_reference(
+        self,
+        *,
+        S0: float = 100.0,
+        r: float = 0.05,
+        T: float = 1.0,
+        **params,
+    ) -> float:
+        r"""Oracle: under the risk-neutral measure :math:`\mathbb{E}[S_T] = S_0 e^{rT}`."""
+        return float(S0 * np.exp(r * T))
 
     def single_simulation(  # pylint: disable=arguments-differ
         self,

--- a/src/mcframework/sims/pi.py
+++ b/src/mcframework/sims/pi.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -57,9 +58,15 @@ class PiEstimationSimulation(MonteCarloSimulation):
     Did you implement .torch_batch() or .curand_batch()? If so, set to True.
     """
 
+    reference_source = "Closed form: 4 * P(X^2 + Y^2 <= 1) = pi"
+
 
     def __init__(self):
         super().__init__("Pi Estimation")
+
+    def analytic_reference(self, **params) -> float:
+        r"""Oracle: :math:`\mathbb{E}[\widehat\pi] = \pi` for every batch size."""
+        return math.pi
 
     def single_simulation(  # pylint: disable=arguments-differ
         self,

--- a/src/mcframework/sims/portfolio.py
+++ b/src/mcframework/sims/portfolio.py
@@ -30,8 +30,31 @@ class PortfolioSimulation(MonteCarloSimulation):
         Default registry label ``"Portfolio Simulation"``.
     """
 
+    reference_source = "Risk-neutral GBM expectation: E[V_T] = V_0 * exp(mu * T)"
+
     def __init__(self):
         super().__init__("Portfolio Simulation")
+
+    def analytic_reference(
+        self,
+        *,
+        initial_value: float = 10_000.0,
+        annual_return: float = 0.07,
+        years: int = 10,
+        use_gbm: bool = True,
+        **params,
+    ) -> float | None:
+        r"""
+        Oracle for the GBM branch: :math:`\mathbb{E}[V_T] = V_0 e^{\mu T}`.
+
+        Although each path applies the drift :math:`(\mu - \tfrac12\sigma^2)\,dt`, the
+        log-normal correction makes the *expected* terminal wealth grow at the raw
+        drift :math:`\mu`. Returns ``None`` for the arithmetic-returns branch
+        (``use_gbm=False``), which has no clean closed form here.
+        """
+        if not use_gbm:
+            return None
+        return float(initial_value * np.exp(annual_return * years))
 
     def single_simulation(  # pylint: disable=arguments-differ
         self,

--- a/src/mcframework/validation.py
+++ b/src/mcframework/validation.py
@@ -178,12 +178,12 @@ def validate_convergence(
     se = float(res.std) / np.sqrt(max(1, n))
 
     bounds = _ci_bounds(res.stats.get("ci_mean"))
+    ci_low: float | None = None
+    ci_high: float | None = None
+    within_ci = False
     if bounds is not None:
         ci_low, ci_high = bounds
         within_ci = ci_low <= oracle <= ci_high
-    else:
-        ci_low = ci_high = None
-        within_ci = False
 
     within_tol = abs_error <= sigma_tol * se
 

--- a/tests/test_oracles.py
+++ b/tests/test_oracles.py
@@ -1,0 +1,70 @@
+"""
+Regression tests pinning the built-in simulations to their analytic references.
+
+Each oracle-backed simulation must converge to its known closed-form answer. These
+are the guardrails that would have caught, e.g., the American LSM look-ahead bug:
+a wrong estimator lands many standard errors away from the oracle and fails.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from mcframework import (
+    BlackScholesPathSimulation,
+    BlackScholesSimulation,
+    PiEstimationSimulation,
+    PortfolioSimulation,
+    validate_convergence,
+)
+
+# (id, sim factory, params, n) for sims that declare an analytic_reference.
+ORACLE_CASES = [
+    ("pi", PiEstimationSimulation, {}, 20_000),
+    ("portfolio_gbm", PortfolioSimulation, {}, 50_000),
+    ("bs_path", BlackScholesPathSimulation, {}, 50_000),
+    ("bs_european_call", BlackScholesSimulation, {"option_type": "call"}, 50_000),
+    ("bs_european_put", BlackScholesSimulation, {"option_type": "put"}, 50_000),
+]
+
+
+@pytest.mark.parametrize(
+    "factory,params,n",
+    [c[1:] for c in ORACLE_CASES],
+    ids=[c[0] for c in ORACLE_CASES],
+)
+def test_builtin_sims_converge_to_oracle(factory, params, n):
+    report = validate_convergence(factory(), n, seed=0, **params)
+    assert report.status == "pass", (
+        f"{factory.__name__} estimate {report.estimate} drifted from oracle "
+        f"{report.oracle} by {report.abs_error} (> {report.sigma_tol} * SE={report.se})"
+    )
+    assert report.within_tol
+    assert report.reference_source  # every oracle-backed sim cites its source
+
+
+def test_pi_oracle_value():
+    assert PiEstimationSimulation().analytic_reference() == math.pi
+
+
+def test_bs_european_matches_textbook_price():
+    # Hull-style benchmark: S0=K=100, r=5%, sigma=20%, T=1 -> call ≈ 10.4506.
+    sim = BlackScholesSimulation()
+    price = sim.analytic_reference(S0=100, K=100, T=1.0, r=0.05, sigma=0.20, option_type="call")
+    assert price == pytest.approx(10.4506, abs=1e-3)
+
+
+def test_american_has_no_oracle():
+    sim = BlackScholesSimulation()
+    assert sim.analytic_reference(exercise_type="american") is None
+    report = validate_convergence(sim, 1_000, exercise_type="american")
+    assert report.status == "no-oracle"
+
+
+def test_portfolio_arithmetic_branch_has_no_oracle():
+    sim = PortfolioSimulation()
+    assert sim.analytic_reference(use_gbm=False) is None
+    report = validate_convergence(sim, 1_000, use_gbm=False)
+    assert report.status == "no-oracle"


### PR DESCRIPTION
## Summary
Second PR of the Oracle and Benchmark Validation System. Wires the `analytic_reference` hook from #62 into every built-in simulation that has a closed-form answer, and pins each to its oracle with parametrized convergence tests. This is where credibility becomes CI-enforced.

> **Stacked on #62** (`feat/oracle-core`). Base is set to `feat/oracle-core` so the diff is clean; retarget to `main` after #62 merges.

Oracles added:
- **Pi** → `math.pi`
- **Portfolio** (GBM branch) → `V0 * exp(mu * T)`; arithmetic branch returns `None`
- **BlackScholesPathSimulation** → `S0 * exp(r * T)`
- **BlackScholesSimulation** (European) → Black-Scholes-Merton closed form (`scipy.stats.norm`); **American returns `None`** — no closed form, deliberately not validated (the governance signal)

## Test plan
- [x] `python3 -m ruff check src/ tests/` clean
- [x] `tests/test_oracles.py` (9 tests): parametrized convergence for all oracle-backed sims at fixed seed; textbook BSM call price ≈ 10.4506; American + arithmetic-portfolio correctly report `no-oracle`
- [x] Full suite: 322 passed, 39 skipped (env-limited `ProcessPoolExecutor` + OOM tests deselected)
- [x] Sphinx build: `guides/validation.md` renders, no new warnings