### PR TITLE
feat(oracle-benchmarks): cited-benchmark support + validation governance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,23 @@ pytest tests/test_core.py -v
 - `test_errors_and_edge_cases.py` - Error handling
 - `test_integration.py` - End-to-end tests
 
+## Adding a Simulation
+
+New simulations must be *validatable*. Before a simulation is advertised as
+production-ready (added to the built-in gallery or recommended in the docs), it must
+declare a checkable ground truth — **either an analytic oracle or a cited benchmark**:
+
+- Implement `analytic_reference(self, **params)` to return the known expected value of a
+  single draw, set `reference_source` (citation) and `reference_kind`
+  (`"closed-form"`, `"benchmark"`, or `"limit"`).
+- Add a convergence regression to `tests/test_oracles.py` asserting
+  `validate_convergence(...).within_tol` at a fixed seed.
+
+A simulation with no checkable reference is research: leave `analytic_reference`
+returning `None` (its reports read `no-oracle`) and label it as draft. See the
+[Oracles and Benchmarks guide](docs/source/guides/validation.md) for the benchmark
+template (cite the source, reproduce the value, show convergence).
+
 ## Code Quality
 
 ### Linting

--- a/demos/demo_convergence_gallery.py
+++ b/demos/demo_convergence_gallery.py
@@ -67,9 +67,11 @@ def sweep_convergence(
 def build_markdown_table(label: str, reports: list[ConvergenceReport]) -> str:
     """Render a Markdown convergence table for one simulation's sweep."""
     source = reports[0].reference_source if reports else ""
+    kind = reports[0].reference_kind if reports else ""
+    kind_label = f" ({kind})" if kind else ""
     lines = [
         f"### {label}",
-        f"*Oracle source: {source}*",
+        f"*Oracle source{kind_label}: {source}*",
         "",
         "| n | estimate | oracle | abs error | abs error / SE | status |",
         "| ---: | ---: | ---: | ---: | ---: | :---: |",

--- a/docs/source/guides/validation.md
+++ b/docs/source/guides/validation.md
@@ -104,6 +104,70 @@ assert report.status == "pass"
 so the oracle can depend on configuration (strike, drift, etc.). Keep the reference a
 genuine closed form or a cited benchmark — never a second Monte Carlo estimate.
 
+## Kinds of reference
+
+Not every credible reference is a closed form. Set `reference_kind` to record which
+flavour of ground truth you are checking against; it is surfaced on every
+{class}`~mcframework.validation.ConvergenceReport`:
+
+| `reference_kind` | Meaning | Example |
+| --- | --- | --- |
+| `"closed-form"` | An exact analytic answer | Black-Scholes-Merton price; $V_0 e^{\mu T}$ |
+| `"benchmark"` | A published, cited reference value | A criticality benchmark $k_\text{eff}$ from a standard suite |
+| `"limit"` | A known asymptotic / limiting value | A large-$n$ or zero-variance limit |
+
+A `"benchmark"` reference lets a domain simulation be validated even when no closed form
+exists: `analytic_reference` returns the published constant and `reference_source`
+carries the citation. The validation machinery is identical — only the provenance of the
+oracle differs.
+
+## Promoting a simulation out of draft
+
+> **Rule:** a simulation may not leave *draft* status (be advertised as production-ready,
+> added to the built-in gallery, or recommended in docs) until it has **either an
+> analytic oracle or a cited benchmark**, wired through `analytic_reference` and pinned
+> by a convergence test in `tests/test_oracles.py`.
+
+This is the governance signal the whole system exists to provide. A simulation with no
+checkable ground truth is research: keep `analytic_reference` returning `None` (its
+reports read `no-oracle`) and label it as draft until a reference exists.
+
+### Benchmark template
+
+When there is no closed form, validate against a published benchmark in three steps:
+
+1. **Cite the source.** Put the full reference in `reference_source` and set
+   `reference_kind = "benchmark"`.
+2. **Reproduce the value.** Have `analytic_reference` return the published constant for
+   the matching parameters (and `None` for any configuration the benchmark does not
+   cover).
+3. **Show convergence.** Add a `tests/test_oracles.py` case asserting
+   `validate_convergence(...).within_tol` at a fixed seed, and (optionally) add the sim
+   to the convergence gallery.
+
+#### Worked example: reactor-physics criticality (not implemented here)
+
+A neutron-transport simulation has no elementary closed form, but the field publishes
+*criticality benchmarks* — configurations with an accepted reference $k_\text{eff}$
+(e.g. the ICSBEP handbook, or an analytic infinite-medium $k_\infty = \nu\Sigma_f /
+\Sigma_a$). The pattern would be:
+
+```python
+class CriticalityBenchmarkSim(MonteCarloSimulation):
+    reference_source = "ICSBEP HEU-MET-FAST-001 (Godiva), k_eff = 1.0000 +/- 0.0010"
+    reference_kind = "benchmark"
+
+    def analytic_reference(self, *, config="godiva", **params):
+        return 1.0000 if config == "godiva" else None  # only the cited config
+
+    def single_simulation(self, _rng=None, **kwargs):
+        ...  # neutron transport estimating k_eff
+```
+
+`mcframework` ships **no** neutron-transport implementation: that remains a separate
+domain effort. What it now provides is the gate — such a simulation is only credible
+once its `k_eff` estimate is shown to converge to the cited benchmark.
+
 ## The convergence gallery
 
 `demos/demo_convergence_gallery.py` sweeps every oracle-backed simulation over

--- a/src/mcframework/sims/black_scholes.py
+++ b/src/mcframework/sims/black_scholes.py
@@ -226,6 +226,7 @@ class BlackScholesSimulation(MonteCarloSimulation):
     """
 
     reference_source = "Black-Scholes-Merton (1973), closed-form European price"
+    reference_kind = "closed-form"
 
     def __init__(self, name: str = "Black-Scholes Option Pricing"):
         super().__init__(name)
@@ -525,6 +526,7 @@ class BlackScholesPathSimulation(MonteCarloSimulation):
     """
 
     reference_source = "Risk-neutral GBM: E[S_T] = S0 * exp(r * T)"
+    reference_kind = "closed-form"
 
     def __init__(self, name: str = "Black-Scholes Path Simulation"):
         super().__init__(name)

--- a/src/mcframework/sims/pi.py
+++ b/src/mcframework/sims/pi.py
@@ -59,6 +59,7 @@ class PiEstimationSimulation(MonteCarloSimulation):
     """
 
     reference_source = "Closed form: 4 * P(X^2 + Y^2 <= 1) = pi"
+    reference_kind = "closed-form"
 
 
     def __init__(self):

--- a/src/mcframework/sims/portfolio.py
+++ b/src/mcframework/sims/portfolio.py
@@ -31,6 +31,7 @@ class PortfolioSimulation(MonteCarloSimulation):
     """
 
     reference_source = "Risk-neutral GBM expectation: E[V_T] = V_0 * exp(mu * T)"
+    reference_kind = "closed-form"
 
     def __init__(self):
         super().__init__("Portfolio Simulation")

--- a/src/mcframework/simulation.py
+++ b/src/mcframework/simulation.py
@@ -115,6 +115,13 @@ class MonteCarloSimulation(ABC):
     #: ``"Black-Scholes-Merton (1973)"``. Empty when no oracle is declared.
     reference_source: str = ""
 
+    #: Kind of reference returned by :meth:`analytic_reference`. One of
+    #: ``"closed-form"`` (an exact analytic answer), ``"benchmark"`` (a published,
+    #: cited reference value), or ``"limit"`` (a known asymptotic/limiting value).
+    #: Empty when no oracle is declared. Used by the validation layer for reporting
+    #: and as the governance signal for promoting a simulation out of draft.
+    reference_kind: str = ""
+
     @property
     def supports_batch(self) -> bool:
         """

--- a/src/mcframework/validation.py
+++ b/src/mcframework/validation.py
@@ -78,6 +78,8 @@ class ConvergenceReport:
         Confidence level used for the interval.
     reference_source : str
         Citation for the oracle, copied from the simulation.
+    reference_kind : str
+        Kind of reference: ``"closed-form"``, ``"benchmark"``, ``"limit"``, or ``""``.
     """
 
     status: str
@@ -94,6 +96,7 @@ class ConvergenceReport:
     sigma_tol: float = 5.0
     confidence: float = 0.99
     reference_source: str = ""
+    reference_kind: str = ""
 
 
 def _ci_bounds(ci: Any) -> tuple[float, float] | None:
@@ -153,6 +156,7 @@ def validate_convergence(
     """
     oracle = sim.analytic_reference(**params)
     reference_source = getattr(sim, "reference_source", "")
+    reference_kind = getattr(sim, "reference_kind", "")
 
     if oracle is None:
         return ConvergenceReport(
@@ -161,6 +165,7 @@ def validate_convergence(
             sigma_tol=sigma_tol,
             confidence=confidence,
             reference_source=reference_source,
+            reference_kind=reference_kind,
         )
 
     oracle = float(oracle)
@@ -202,4 +207,5 @@ def validate_convergence(
         sigma_tol=sigma_tol,
         confidence=confidence,
         reference_source=reference_source,
+        reference_kind=reference_kind,
     )

--- a/src/mcframework/validation.py
+++ b/src/mcframework/validation.py
@@ -183,12 +183,12 @@ def validate_convergence(
     se = float(res.std) / np.sqrt(max(1, n))
 
     bounds = _ci_bounds(res.stats.get("ci_mean"))
+    ci_low: float | None = None
+    ci_high: float | None = None
+    within_ci = False
     if bounds is not None:
         ci_low, ci_high = bounds
         within_ci = ci_low <= oracle <= ci_high
-    else:
-        ci_low = ci_high = None
-        within_ci = False
 
     within_tol = abs_error <= sigma_tol * se
 

--- a/tests/test_oracles.py
+++ b/tests/test_oracles.py
@@ -43,6 +43,7 @@ def test_builtin_sims_converge_to_oracle(factory, params, n):
     )
     assert report.within_tol
     assert report.reference_source  # every oracle-backed sim cites its source
+    assert report.reference_kind == "closed-form"  # built-ins are all closed-form
 
 
 def test_pi_oracle_value():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -49,6 +49,13 @@ class WrongOracleSim(UniformMeanSim):
         return 5.0
 
 
+class BenchmarkSim(UniformMeanSim):
+    """A simulation validated against a cited benchmark rather than a closed form."""
+
+    reference_source = "Made-up benchmark, Author et al. (2026)"
+    reference_kind = "benchmark"
+
+
 def test_pass_within_tolerance():
     report = validate_convergence(UniformMeanSim(), 20_000, seed=0)
     assert isinstance(report, ConvergenceReport)
@@ -84,6 +91,18 @@ def test_reproducible_at_fixed_seed():
     b = validate_convergence(UniformMeanSim(), 5_000, seed=123)
     assert a.estimate == b.estimate
     assert a.se == b.se
+
+
+def test_reference_kind_is_surfaced():
+    # Default (closed-form) and benchmark kinds both propagate into the report,
+    # including on the no-oracle short-circuit path.
+    closed = validate_convergence(UniformMeanSim(), 2_000, seed=0)
+    assert closed.reference_kind == ""  # UniformMeanSim leaves kind unset
+    bench = validate_convergence(BenchmarkSim(), 2_000, seed=0)
+    assert bench.reference_kind == "benchmark"
+    assert bench.reference_source == "Made-up benchmark, Author et al. (2026)"
+    no_oracle = validate_convergence(NoOracleSim(), 100)
+    assert no_oracle.reference_kind == ""
 
 
 def test_rel_error_and_se_are_consistent():


### PR DESCRIPTION
## Summary
Fourth and final PR of the Oracle and Benchmark Validation System. Generalizes the oracle hook beyond closed forms so domain simulations (neutron transport, American options, …) have a credible off-ramp, and documents the governance rule the whole system exists to enforce.

> **Stacked on #64** (`feat/oracle-gallery`). Base is set to `feat/oracle-gallery` for a clean diff; retarget to `main` as the stack merges.

- `reference_kind` (`"closed-form"` | `"benchmark"` | `"limit"`) added to `MonteCarloSimulation`; `reference_kind` and `reference_source` surfaced on `ConvergenceReport` (including the `no-oracle` path) and in the gallery table.
- Built-in sims tagged `closed-form`.
- **Governance docs**: `guides/validation.md` gains a reference-kinds table, the "a simulation needs an oracle or a cited benchmark to leave draft" rule, and a worked reactor-physics benchmark template — **without** implementing neutron transport (that remains a separate domain effort, now gated by this system).
- `CONTRIBUTING.md`: contributor rule requiring an oracle or cited benchmark before a sim is promoted.

## Test plan
- [x] `python3 -m ruff check src/ tests/` clean
- [x] `tests/test_validation.py` + `tests/test_oracles.py`: assert `reference_kind` propagates for closed-form, benchmark, and no-oracle cases
- [x] Full suite: 328 passed, 39 skipped (env-limited `ProcessPoolExecutor` + OOM tests deselected)
- [x] Sphinx build: no new warnings