### PR TITLE
fix(stats): correct sample-mean MSE/Markov bound + engine observability

### DIFF
--- a/src/mcframework/__init__.py
+++ b/src/mcframework/__init__.py
@@ -1,5 +1,6 @@
 """mcframework package public API."""
 
+import logging
 from importlib.metadata import PackageNotFoundError, version
 
 # Profiling submodule (imported as submodule, not exposed at top level)
@@ -14,6 +15,11 @@ from .sims import (
 from .stats_engine import DEFAULT_ENGINE, FnMetric, StatsContext, StatsEngine
 from .utils import autocrit, t_crit, z_crit
 from .validation import ConvergenceReport, validate_convergence
+
+# Library logging best practice: attach a no-op handler to the package root so
+# importing mcframework never emits "No handlers could be found" warnings and
+# never imposes logging configuration on the host application.
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     "SimulationResult",

--- a/src/mcframework/backends/parallel.py
+++ b/src/mcframework/backends/parallel.py
@@ -126,7 +126,7 @@ class ThreadBackend:
                 results[i:j] = arr
                 completed += j - i
                 if progress_callback:
-                    progress_callback(completed, n_simulations)  # pragma: no cover
+                    progress_callback(completed, n_simulations)
 
         return results
 

--- a/src/mcframework/simulation.py
+++ b/src/mcframework/simulation.py
@@ -43,6 +43,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .backends import ProcessBackend, SequentialBackend, ThreadBackend, is_windows_platform
+from .backends.parallel import _CHUNKS_PER_WORKER as _DEFAULT_CHUNKS_PER_WORKER
 from .stats_engine import (
     _PCTS as _ENGINE_PCTS,
 )
@@ -104,8 +105,9 @@ class MonteCarloSimulation(ABC):
     _PCTS = _ENGINE_PCTS
     # Minimum simulations to use parallel execution (soft limit)
     _PARALLEL_THRESHOLD = 20_000
-    # Number of chunks per worker for load balancing (ensures dynamic work distribution)
-    _CHUNKS_PER_WORKER = 8
+    # Number of chunks per worker for load balancing (ensures dynamic work distribution).
+    # Single source of truth lives in mcframework.backends.parallel.
+    _CHUNKS_PER_WORKER = _DEFAULT_CHUNKS_PER_WORKER
 
     #: Whether this simulation supports batch GPU execution.
     #: Override in subclass by setting ``supports_batch = True``.
@@ -421,18 +423,21 @@ class MonteCarloSimulation(ABC):
         ci_method: str,
         stats_engine: StatsEngine | None,
         extra_context: Mapping[str, Any] | None,
-    ) -> tuple[dict[str, Any], dict[int, float]]:
+    ) -> tuple[dict[str, Any], dict[int, float], dict[str, list[tuple[str, str]]]]:
         """
         Compute statistics using the stats engine.
 
         Returns
         -------
-        tuple[dict[str, Any], dict[int, float]]
-            (stats dict, percentiles dict)
+        tuple[dict[str, Any], dict[int, float], dict[str, list[tuple[str, str]]]]
+            ``(stats dict, percentiles dict, diagnostics)`` where ``diagnostics``
+            carries the engine's ``skipped`` and ``errors`` so swallowed metric
+            failures remain visible in the assembled result.
         """
+        diagnostics: dict[str, list[tuple[str, str]]] = {"skipped": [], "errors": []}
         eng = stats_engine or DEFAULT_ENGINE
         if eng is None:
-            return {}, {}
+            return {}, {}, diagnostics
 
         engine_defaults = self._PCTS
 
@@ -460,9 +465,18 @@ class MonteCarloSimulation(ABC):
         try:
             result = eng.compute(results, ctx)
             stats = result.metrics if hasattr(result, "metrics") else {}
+            diagnostics["skipped"] = list(getattr(result, "skipped", []))
+            diagnostics["errors"] = list(getattr(result, "errors", []))
+            if diagnostics["errors"]:
+                logger.warning(
+                    "Stats engine reported %d errored metric(s): %s",
+                    len(diagnostics["errors"]),
+                    [name for name, _ in diagnostics["errors"]],
+                )
         except (ValueError, TypeError, ArithmeticError, RuntimeError) as e:
             logger.error("Stats engine failed: %s", e)
             stats = {}
+            diagnostics["errors"] = [("<engine>", str(e))]
 
         # Merge engine stats with baseline (engine wins on collisions)
         baseline = self._compute_stats_block(results, ctx)
@@ -477,7 +491,7 @@ class MonteCarloSimulation(ABC):
 
         percentile_map = {int(k): float(v) for k, v in engine_perc.items()}
 
-        return stats, percentile_map
+        return stats, percentile_map, diagnostics
 
     def _handle_percentiles(
         self,
@@ -625,9 +639,10 @@ class MonteCarloSimulation(ABC):
         # Compute stats and percentiles
         stats: dict[str, Any] = {}
         percentile_map: dict[int, float] = {}
+        diagnostics: dict[str, list[tuple[str, str]]] = {"skipped": [], "errors": []}
 
         if compute_stats:
-            stats, percentile_map = self._compute_stats_with_engine(
+            stats, percentile_map, diagnostics = self._compute_stats_with_engine(
                 results, n_simulations, confidence, ci_method, stats_engine, extra_context
             )
 
@@ -643,6 +658,7 @@ class MonteCarloSimulation(ABC):
             stats,
             requested_percentiles,
             engine_defaults_used,
+            diagnostics,
         )
 
     def _resolve_backend_type(self, requested: str | None = None) -> str:
@@ -862,6 +878,7 @@ class MonteCarloSimulation(ABC):
         stats: dict[str, Any],
         requested_percentiles: list[int],
         engine_defaults_used: bool,
+        diagnostics: Mapping[str, list[tuple[str, str]]] | None = None,
     ) -> SimulationResult:
         r"""
         Assemble a :class:`SimulationResult` and merge any stats-engine percentiles.
@@ -870,7 +887,10 @@ class MonteCarloSimulation(ABC):
         -----
         Preserves the user's requested percentiles in
         ``metadata["requested_percentiles"]`` and whether engine defaults were used
-        in ``metadata["engine_defaults_used"]``.
+        in ``metadata["engine_defaults_used"]``. Any engine metrics that were
+        skipped or errored are surfaced in ``metadata["stats_skipped"]`` /
+        ``metadata["stats_errors"]`` (only when non-empty) so silent failures stay
+        visible in the returned result, not only in logs.
         """
         # Import here to avoid circular dependency
         from .core import SimulationResult  # pylint: disable=import-outside-toplevel
@@ -909,6 +929,14 @@ class MonteCarloSimulation(ABC):
             "requested_percentiles": requested_percentiles,
             "engine_defaults_used": engine_defaults_used,
         }
+
+        # Surface engine diagnostics only when there is something to report, so the
+        # common all-succeeded case doesn't clutter metadata / printed summaries.
+        if diagnostics:
+            if diagnostics.get("skipped"):
+                meta["stats_skipped"] = list(diagnostics["skipped"])
+            if diagnostics.get("errors"):
+                meta["stats_errors"] = list(diagnostics["errors"])
 
         return SimulationResult(
             results=results,

--- a/src/mcframework/stats_engine.py
+++ b/src/mcframework/stats_engine.py
@@ -154,7 +154,7 @@ class BootstrapMethod(str, Enum):
 
 
 
-@dataclass(slots=True)
+@dataclass(slots=True, frozen=True)
 class StatsContext:
     r"""
     Shared, explicit configuration for statistic and CI computations.
@@ -205,8 +205,6 @@ class StatsContext:
         Number of bootstrap resamples for :func:`ci_mean_bootstrap`.
     bootstrap : {"percentile", "bca"}, default "percentile"
         Bootstrap flavor for :func:`ci_mean_bootstrap`.
-    block_size : int, optional
-        Reserved for future block bootstrap support.
 
     Notes
     -----
@@ -1411,11 +1409,15 @@ def markov_error_prob(x: np.ndarray, ctx: StatsContext) -> float:
     Markov bound on error probability for target :math:`\theta`.
 
     Using the squared error of the sample mean,
-    :math:`\mathrm{MSE}(\bar X) \approx \frac{s^2}{n} + \text{Bias}^2`, Markov gives
+    :math:`\mathrm{MSE}(\bar X) \approx \frac{s^2}{n_\text{eff}} + \text{Bias}^2`,
+    Markov gives
 
     .. math::
        \Pr\!\left(\,|\bar X - \theta| \ge \varepsilon\,\right)
-       \;\le\; \frac{\mathrm{MSE}}{\varepsilon^2}.
+       \;\le\; \frac{\mathrm{MSE}(\bar X)}{\varepsilon^2}.
+
+    The :math:`\mathrm{MSE}(\bar X)` term is delegated to :func:`mse_to_target`
+    so the two metrics share a single definition of estimator MSE.
 
     Parameters
     ----------
@@ -1423,14 +1425,13 @@ def markov_error_prob(x: np.ndarray, ctx: StatsContext) -> float:
         Input sample.
     ctx : StatsContext or Mapping
         Requires :attr:`~mcframework.stats_engine.StatsContext.target` and
-        :attr:`~mcframework.stats_engine.StatsContext.eps`. The declared
-        :attr:`~mcframework.stats_engine.StatsContext.n` influences the context but does not enter
-        directly into the bound.
+        :attr:`~mcframework.stats_engine.StatsContext.eps`. The effective sample
+        size enters the bound through the :math:`s^2/n_\text{eff}` variance term.
 
     Returns
     -------
     float
-        Upper bound in :math:`[0, 1]`.
+        Upper bound (non-negative; can exceed 1 when the bound is vacuous).
     """
     ctx = _ensure_ctx(ctx, x)
     if ctx.target is None:
@@ -1439,9 +1440,7 @@ def markov_error_prob(x: np.ndarray, ctx: StatsContext) -> float:
         raise MissingContextError("markov_error_prob requires ctx.eps")
     if ctx.eps <= 0:
         raise ValueError("ctx.eps must be positive")
-    arr, _ = _clean(x, ctx)
-    mse = float(np.mean((arr - ctx.target) ** 2))
-    return mse / (ctx.eps**2)
+    return mse_to_target(x, ctx) / (ctx.eps**2)
 
 
 def bias_to_target(x: np.ndarray, ctx: StatsContext) -> float:
@@ -1473,10 +1472,15 @@ def mse_to_target(x: np.ndarray, ctx: StatsContext) -> float:
     r"""
     Mean squared error of :math:`\bar X` relative to a target :math:`\theta`.
 
-    Approximated by
+    Estimates the MSE of the sample mean :math:`\bar X` as an estimator of
+    :math:`\theta`:
 
     .. math::
-       \mathrm{MSE}(\bar X) \approx \frac{s^2}{n} + (\bar X - \theta)^2.
+       \mathrm{MSE}(\bar X) \approx \frac{s^2}{n_\text{eff}} + (\bar X - \theta)^2,
+
+    i.e. the variance of the sample mean plus the squared bias. When the
+    variance cannot be estimated (:math:`n_\text{eff} \le \texttt{ddof}`), only
+    the squared-bias term is returned.
 
     Parameters
     ----------
@@ -1488,13 +1492,22 @@ def mse_to_target(x: np.ndarray, ctx: StatsContext) -> float:
     Returns
     -------
     float
-        Estimated mean squared error relative to ``target``.
+        Estimated mean squared error of :math:`\bar X` relative to ``target``.
     """
     ctx = _ensure_ctx(ctx, x)
     if ctx.target is None:
         raise MissingContextError("mse_to_target requires ctx.target")
-    arr, _ = _clean(x, ctx)
-    return float(np.mean((arr - ctx.target) ** 2))
+    sample_mean = mean(x, ctx)
+    if sample_mean is None:
+        raise InsufficientDataError("mse_to_target requires non-empty data after cleaning")
+    bias = sample_mean - ctx.target
+    n_eff = _effective_sample_size(x, ctx)
+    sample_std = std(x, ctx)
+    # std() returns None when n_eff <= ddof (variance unestimable); fall back to
+    # the squared-bias term alone.
+    if sample_std is None or n_eff <= 0:
+        return float(bias**2)
+    return float(sample_std**2 / n_eff + bias**2)
 
 
 def build_default_engine(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -776,7 +776,7 @@ def test_compute_stats_with_none_engine():
 
     # Patch DEFAULT_ENGINE to be None
     with patch('mcframework.simulation.DEFAULT_ENGINE', None):
-        stats, percentiles = sim._compute_stats_with_engine(
+        stats, percentiles, diagnostics = sim._compute_stats_with_engine(
             results=np.array([1.0, 2.0, 3.0]),
             n_simulations=3,
             confidence=0.95,
@@ -786,6 +786,7 @@ def test_compute_stats_with_none_engine():
         )
         assert stats == {}
         assert percentiles == {}
+        assert diagnostics == {"skipped": [], "errors": []}
 
 
 def test_resolve_backend_type_explicit_thread():

--- a/tests/test_distribution_free_metrics.py
+++ b/tests/test_distribution_free_metrics.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from mcframework.stats_engine import (
+    StatsContext,
     bias_to_target,
     chebyshev_required_n,
     markov_error_prob,
@@ -57,6 +58,39 @@ class TestDistributionFreeMetrics:
         result = mse_to_target(data, ctx)
         assert result is not None
         assert result >= 0  # MSE is always non-negative
+
+    def test_mse_to_target_is_estimator_mse(self):
+        """[FR-16] MSE of the sample mean = s^2/n_eff + bias^2 (not per-observation)."""
+        # arr=[1..5], target=3 => mean=3 (zero bias), sample var (ddof=1)=2.5, n=5
+        # MSE(X_bar) = 2.5/5 + 0 = 0.5  (the per-observation mean sq dev would be 2.0)
+        arr = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        ctx = StatsContext(n=5, target=3.0)
+        assert mse_to_target(arr, ctx) == pytest.approx(0.5)
+
+    def test_mse_to_target_constant_data_is_squared_bias(self):
+        """[FR-16] Zero-variance data => MSE collapses to bias^2."""
+        arr = np.full(4, 2.0)
+        ctx = StatsContext(n=4, target=0.0)
+        assert mse_to_target(arr, ctx) == pytest.approx(4.0)
+
+    def test_markov_bound_scales_with_n(self):
+        """[FR-16] Markov bound on |X_bar - target| must shrink with n (uses s^2/n)."""
+        # Same per-sample spread, different n: the sample-mean error bound must fall ~1/n.
+        rng = np.random.default_rng(0)
+        small = rng.normal(0.0, 1.0, 100)
+        large = rng.normal(0.0, 1.0, 10_000)
+        eps = 0.5
+        b_small = markov_error_prob(small, StatsContext(n=small.size, target=0.0, eps=eps))
+        b_large = markov_error_prob(large, StatsContext(n=large.size, target=0.0, eps=eps))
+        # Larger n => tighter (smaller) bound on the mean's error.
+        assert b_large < b_small
+
+    def test_markov_equals_mse_over_eps_squared(self):
+        """[FR-16] markov_error_prob == mse_to_target / eps^2 (shared definition)."""
+        arr = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        ctx = StatsContext(n=5, target=3.0, eps=2.0)
+        expected = mse_to_target(arr, ctx) / (2.0**2)
+        assert markov_error_prob(arr, ctx) == pytest.approx(expected)
 
     def test_bias_to_target_empty_data_after_cleaning(self):
         """[NFR-4] Test bias_to_target raises InsufficientDataError with empty data after cleaning."""

--- a/tests/test_performance_and_concurrency.py
+++ b/tests/test_performance_and_concurrency.py
@@ -2,6 +2,29 @@
 import numpy as np
 
 from mcframework.backends.base import worker_run_chunk
+from mcframework.backends.parallel import ThreadBackend
+
+
+def test_thread_backend_invokes_progress_callback(simple_simulation):
+    """[NFR-7] ThreadBackend reports progress per completed block and reaches the total."""
+    simple_simulation.set_seed(42)
+    seed_seq = np.random.SeedSequence(42)
+    calls: list[tuple[int, int]] = []
+
+    backend = ThreadBackend(n_workers=2)
+    results = backend.run(
+        simple_simulation,
+        n_simulations=100,
+        seed_seq=seed_seq,
+        progress_callback=lambda done, total: calls.append((done, total)),
+    )
+
+    assert results.shape == (100,)
+    assert calls, "progress_callback was never invoked"
+    assert all(total == 100 for _, total in calls)
+    # Progress is monotonically non-decreasing and ends at the total.
+    assert [done for done, _ in calls] == sorted(done for done, _ in calls)
+    assert calls[-1][0] == 100
 
 
 class TestPerformance:

--- a/tests/test_stats_engine_edge_cases.py
+++ b/tests/test_stats_engine_edge_cases.py
@@ -398,3 +398,58 @@ def test_ci_mean_chebyshev_with_none_mean_or_std():
     with patch('mcframework.stats_engine.std', return_value=None):
         result = ci_mean_chebyshev(data, ctx)
         assert result is None
+
+
+def test_bca_acceleration_zero_for_symmetric_data():
+    """Acceleration factor a = 0 when the jackknife distribution is symmetric."""
+    from mcframework.stats_engine import _bca_acceleration
+
+    arr = np.array([-2.0, -1.0, 0.0, 1.0, 2.0])
+    assert _bca_acceleration(arr) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_bca_bias_correction_zero_when_median_unbiased():
+    """Bias correction z0 = 0 when exactly half the bootstrap means fall below the mean."""
+    from mcframework.stats_engine import _bca_bias_correction
+
+    arr = np.array([0.0, 1.0, 2.0, 3.0])  # m_hat = 1.5
+    boot_means = np.array([1.0, 1.0, 2.0, 2.0])  # 2 of 4 below 1.5 => prop = 0.5
+    assert _bca_bias_correction(arr, boot_means) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_bca_matches_percentile_for_symmetric_sample():
+    """For symmetric data (z0~0, a~0), BCa should closely track the percentile CI."""
+    arr = np.linspace(-5.0, 5.0, num=201)
+    perc = ci_mean_bootstrap(
+        arr, StatsContext(n=arr.size, n_bootstrap=4000, rng=7, bootstrap="percentile")
+    )
+    bca = ci_mean_bootstrap(
+        arr, StatsContext(n=arr.size, n_bootstrap=4000, rng=7, bootstrap="bca")
+    )
+    width = perc["high"] - perc["low"]
+    assert bca["low"] == pytest.approx(perc["low"], abs=0.1 * width)
+    assert bca["high"] == pytest.approx(perc["high"], abs=0.1 * width)
+
+
+def test_bootstrap_means_row_chunking_branch(monkeypatch):
+    """total_elements > limit but n <= limit triggers the row-chunked path."""
+    import mcframework.stats_engine as se
+
+    monkeypatch.setattr(se, "_BOOTSTRAP_CHUNK_LIMIT", 50)
+    arr = np.arange(10, dtype=float)  # n=10 <= 50
+    rng = np.random.default_rng(0)
+    means = se._bootstrap_means(arr, n_resamples=100, rng=rng)  # total=1000 > 50
+    assert means.shape == (100,)
+    assert means.min() >= arr.min() and means.max() <= arr.max()
+
+
+def test_bootstrap_means_column_chunking_branch(monkeypatch):
+    """n > limit triggers the per-resample column-accumulation path."""
+    import mcframework.stats_engine as se
+
+    monkeypatch.setattr(se, "_BOOTSTRAP_CHUNK_LIMIT", 50)
+    arr = np.arange(100, dtype=float)  # n=100 > 50
+    rng = np.random.default_rng(0)
+    means = se._bootstrap_means(arr, n_resamples=5, rng=rng)
+    assert means.shape == (5,)
+    assert means.min() >= arr.min() and means.max() <= arr.max()


### PR DESCRIPTION
## Summary

Implements the Statistics Engine review fix plan. Three strategic commits:

- **fix(stats): correct sample-mean MSE/Markov bound + freeze StatsContext** — `mse_to_target` / `markov_error_prob` were computing the per-observation mean squared deviation `E[(X-target)^2]` instead of the estimator MSE of the sample mean. This made `markov_error_prob` an invalid bound on `P(|X_bar - target| >= eps)` (variance term was off by a factor of ~n). Both now use `MSE(X_bar) = s^2/n_eff + bias^2`, with `markov_error_prob` delegating to `mse_to_target` for a single source of truth. Also `frozen=True` on `StatsContext` (matches its "immutable by convention" docstring) and dropped the phantom `block_size` docstring attribute.
- **feat(stats): surface engine diagnostics + library NullHandler** — engine `skipped`/`errors` were silently dropped at the simulation boundary; they are now threaded into `SimulationResult.metadata["stats_skipped"]` / `["stats_errors"]` (only when non-empty) and warned on. Added a package-root `NullHandler` (library logging best practice). De-duplicated `_CHUNKS_PER_WORKER`.
- **test(backends): cover ThreadBackend progress callback** — removed `# pragma: no cover` and added a monotonic-progress test.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] Full suite: 356 passed, 22 skipped (GPU auto-skip), 1 deselected (documented OOM test)
- [x] `parallel.py` 100% / `stats_engine.py` 99% coverage
- [x] CI green on this PR

## Notes

No existing test pinned the old (buggy) `markov`/`mse` numeric values, and no demo uses these metrics, so the math change is behavior-correcting only. Base is `feat/oracle-benchmarks` (this work is stacked on it) to keep the diff isolated to the review fixes.